### PR TITLE
Provide behavioral array example with testbench

### DIFF
--- a/array_db.v
+++ b/array_db.v
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// File: array_db.v
+// Description: Simple synchronous memory using behavioral modeling.
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Module: array_behavioral_simple
+// Feature: parameterized memory with synchronous write and registered read
+//------------------------------------------------------------------------------
+module array_behavioral_simple #(parameter WIDTH=8, DEPTH=4, ADDR=2) (
+  input                 clk,
+  input  [WIDTH-1:0]    write_data,
+  input  [ADDR-1:0]     write_addr,
+  input                 write_en,
+  input  [ADDR-1:0]     read_addr,
+  output reg [WIDTH-1:0] read_data
+);
+  // memory array
+  reg [WIDTH-1:0] mem_array [DEPTH-1:0];
+  integer i;
+
+  // initialize memory and output to known values
+  initial begin
+    for (i = 0; i < DEPTH; i = i + 1)
+      mem_array[i] = {WIDTH{1'b0}};
+    read_data = {WIDTH{1'b0}};
+  end
+
+  // synchronous write and registered read
+  always @(posedge clk) begin
+    read_data <= mem_array[read_addr];
+    if (write_en)
+      mem_array[write_addr] <= write_data;
+  end
+endmodule
+

--- a/array_db_tb.v
+++ b/array_db_tb.v
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// Testbench: array_db_tb
+// Description: Runs basic tests for array_behavioral_simple memory.
+//------------------------------------------------------------------------------
+`timescale 1ns/1ps
+module array_db_tb;
+  // function to compute address width
+  function integer clog2;
+    input integer value; integer i;
+    begin
+      value = value - 1;
+      for (i = 0; value > 0; i = i + 1)
+        value = value >> 1;
+      clog2 = i;
+    end
+  endfunction
+
+  localparam WIDTH = 8;
+  localparam DEPTH = 4;
+  localparam ADDR  = clog2(DEPTH);
+
+  // shared clock
+  reg clk;
+  initial clk = 0;
+  always #5 clk = ~clk;
+
+  // signals for memory
+  reg [WIDTH-1:0] write_data;
+  reg [ADDR-1:0] write_addr;
+  reg write_en;
+  reg [ADDR-1:0] read_addr;
+  wire [WIDTH-1:0] read_data;
+
+  array_behavioral_simple #(.WIDTH(WIDTH), .DEPTH(DEPTH), .ADDR(ADDR)) dut (
+    .clk(clk), .write_data(write_data), .write_addr(write_addr),
+    .write_en(write_en), .read_addr(read_addr), .read_data(read_data)
+  );
+
+  integer i; integer errors;
+  initial begin
+    errors = 0;
+    write_en = 0; write_data = 0; write_addr = 0; read_addr = 0;
+    // write pattern
+    for (i = 0; i < DEPTH; i = i + 1) begin
+      @(negedge clk);
+      write_en = 1;
+      write_addr = i[ADDR-1:0];
+      write_data = i * 8'h11;
+    end
+    @(negedge clk);
+    write_en = 0;
+    // readback
+    for (i = 0; i < DEPTH; i = i + 1) begin
+      read_addr = i[ADDR-1:0];
+      @(posedge clk);
+      #1;
+      if (read_data !== i * 8'h11) begin
+        $display("Mismatch at %0d: expected %0h got %0h", i, i * 8'h11, read_data);
+        errors = errors + 1;
+      end
+    end
+    if (errors == 0)
+      $display("array_behavioral_simple PASS");
+    else
+      $display("array_behavioral_simple FAIL with %0d errors", errors);
+    $display("array_db_tb complete");
+    $finish;
+  end
+endmodule
+


### PR DESCRIPTION
## Summary
- Simplify array module to a single behavioral implementation with synchronous write and registered read
- Revise testbench to exercise the behavioral array and ensure deterministic timing

## Testing
- `iverilog -o array_db_tb.out array_db.v array_db_tb.v && vvp array_db_tb.out`


------
https://chatgpt.com/codex/tasks/task_e_68adeb465e088331ab92b4681e233fb2