### PR TITLE
Add simple FIFO count output and test coverage

### DIFF
--- a/async_fifo.v
+++ b/async_fifo.v
@@ -12,6 +12,7 @@
 //   read_data       - data bus seen when reading
 //   full            - high when FIFO cannot take more writes
 //   empty           - high when FIFO has nothing to read
+//   count           - number of stored words for simple occupancy tracking
 //   fifo_mem        - array that keeps all data words
 //   write_ptr_bin   - binary form of write pointer
 //   write_ptr_gray  - write pointer changed into Gray code
@@ -34,7 +35,7 @@ module async_fifo #(
 )(
   write_clk, write_reset_n, write_en, write_data,
   read_clk, read_reset_n, read_en, read_data,
-  full, empty
+  full, empty, count
 );
   // manual clog2 function avoids extra include files and stays in plain Verilog-2001
   function integer clog2;
@@ -59,6 +60,7 @@ module async_fifo #(
   output [DATA_WIDTH-1:0]   read_data;
   output                    full;
   output                    empty;
+  output [ADDR:0]           count;
   reg [DATA_WIDTH-1:0] fifo_mem [0:DEPTH-1];
   // FIFO memory seen by both clocks; array works like simple dual-port RAM
   reg [ADDR:0] write_ptr_bin, write_ptr_gray, read_ptr_bin, read_ptr_gray;
@@ -105,6 +107,7 @@ module async_fifo #(
   wire [ADDR:0] write_ptr_bin_sync, read_ptr_bin_sync;
   assign write_ptr_bin_sync = gray2bin(write_ptr_gray_sync2);
   assign read_ptr_bin_sync = gray2bin(read_ptr_gray_sync2);
+  assign count = write_ptr_bin - read_ptr_bin_sync;
   // status flags
   // FIFO is full when write pointer wrapped once beyond synced read pointer
   assign full  = ( (write_ptr_gray[ADDR:ADDR-1] == ~read_ptr_gray_sync2[ADDR:ADDR-1]) &&

--- a/async_fifo_tb.v
+++ b/async_fifo_tb.v
@@ -22,17 +22,29 @@
 module async_fifo_tb;
   localparam DATA_WIDTH = 8;
   localparam DEPTH      = 4;
+  function integer clog2;
+    input integer value;
+    integer i;
+    begin
+      value = value - 1;
+      for (i = 0; value > 0; i = i + 1)
+        value = value >> 1;
+      clog2 = i;
+    end
+  endfunction
+  localparam ADDR = clog2(DEPTH);
 
   reg write_clk, write_reset_n, write_en;
   reg [DATA_WIDTH-1:0] write_data;
   reg read_clk, read_reset_n, read_en;
   wire [DATA_WIDTH-1:0] read_data;
   wire full, empty;
+  wire [ADDR:0] count;
 
   async_fifo #(.DATA_WIDTH(DATA_WIDTH), .DEPTH(DEPTH)) dut(
     .write_clk(write_clk), .write_reset_n(write_reset_n), .write_en(write_en), .write_data(write_data),
     .read_clk(read_clk), .read_reset_n(read_reset_n), .read_en(read_en), .read_data(read_data),
-    .full(full), .empty(empty)
+    .full(full), .empty(empty), .count(count)
   );
 
   initial begin write_clk = 0; forever #5 write_clk = ~write_clk; end
@@ -60,6 +72,10 @@ module async_fifo_tb;
       expected[i] = i * 8'h44;    // store for later comparison
     end
     @(posedge write_clk); write_en = 0; // stop writing
+    if (count !== DEPTH) begin
+      $display("Count mismatch after writes: expected %0d got %0d", DEPTH, count);
+      errors = errors + 1;
+    end
 
     // allow time before reading
     repeat (4) @(posedge read_clk);
@@ -78,6 +94,11 @@ module async_fifo_tb;
       end
     end
     @(posedge read_clk); read_en = 0; // stop reading
+    repeat (4) @(posedge write_clk);
+    if (count !== 0) begin
+      $display("Count mismatch after reads: expected 0 got %0d", count);
+      errors = errors + 1;
+    end
 
     if (errors == 0)
       $display("async_fifo_tb PASS");


### PR DESCRIPTION
## Summary
- expose a `count` output from `async_fifo` to report words stored
- extend testbench to compute address width, connect `count`, and check it after writes and reads

## Testing
- `iverilog -g2012 -o async_fifo_tb.vvp async_fifo_tb.v async_fifo.v && vvp async_fifo_tb.vvp`


------
https://chatgpt.com/codex/tasks/task_e_68adf64b282c8331a1a40d38c863a5e7