### PR TITLE
Add behavioral, dataflow, and structural up/down counters with unified testbench

### DIFF
--- a/up_down_counter_behavioral.v
+++ b/up_down_counter_behavioral.v
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// Module: up_down_counter_behavioral
+// Feature: 4-bit synchronous up/down counter (behavioral)
+// Reference: Based on Morris Mano's textbook design
+//------------------------------------------------------------------------------
+module up_down_counter_behavioral (
+  input  wire       clk,
+  input  wire       reset,
+  input  wire       up,
+  output reg  [3:0] count
+);
+  always @(posedge clk or posedge reset) begin
+    if (reset)
+      count <= 4'b0000;       // reset clears counter to 0
+    else if (up)
+      count <= count + 1'b1;  // increment when up=1
+    else
+      count <= count - 1'b1;  // decrement when up=0
+  end
+endmodule

--- a/up_down_counter_dataflow.v
+++ b/up_down_counter_dataflow.v
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// Module: up_down_counter_dataflow
+// Feature: 4-bit synchronous up/down counter (dataflow)
+// Reference: Based on Morris Mano's textbook design
+//------------------------------------------------------------------------------
+module up_down_counter_dataflow (
+  input  wire       clk,
+  input  wire       reset,
+  input  wire       up,
+  output reg  [3:0] count
+);
+  wire [3:0] inc = count + 4'b0001;
+  wire [3:0] dec = count - 4'b0001;
+  wire [3:0] next = up ? inc : dec;
+  always @(posedge clk or posedge reset) begin
+    if (reset)
+      count <= 4'b0000;
+    else
+      count <= next;
+  end
+endmodule

--- a/up_down_counter_structural.v
+++ b/up_down_counter_structural.v
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+// Module: up_down_counter_structural
+// Feature: 4-bit synchronous up/down counter (structural)
+// Reference: Based on Morris Mano's textbook design
+//------------------------------------------------------------------------------
+module dff (
+  input  wire clk,
+  input  wire reset,
+  input  wire d,
+  output reg  q
+);
+  always @(posedge clk or posedge reset) begin
+    if (reset)
+      q <= 1'b0;
+    else
+      q <= d;
+  end
+endmodule
+
+module full_adder (
+  input  wire a,
+  input  wire b,
+  input  wire cin,
+  output wire sum,
+  output wire cout
+);
+  assign sum  = a ^ b ^ cin;
+  assign cout = (a & b) | (b & cin) | (a & cin);
+endmodule
+
+module up_down_counter_structural (
+  input  wire       clk,
+  input  wire       reset,
+  input  wire       up,
+  output wire [3:0] count
+);
+  wire [3:0] q;
+  wire [3:0] b;
+  wire [3:0] sum;
+  wire c0, c1, c2, c3;
+  assign b = up ? 4'b0001 : 4'b1111; // +1 when up, -1 when down
+
+  full_adder fa0 (.a(q[0]), .b(b[0]), .cin(1'b0), .sum(sum[0]), .cout(c0));
+  full_adder fa1 (.a(q[1]), .b(b[1]), .cin(c0),    .sum(sum[1]), .cout(c1));
+  full_adder fa2 (.a(q[2]), .b(b[2]), .cin(c1),    .sum(sum[2]), .cout(c2));
+  full_adder fa3 (.a(q[3]), .b(b[3]), .cin(c2),    .sum(sum[3]), .cout(c3));
+
+  dff dff0 (.clk(clk), .reset(reset), .d(sum[0]), .q(q[0]));
+  dff dff1 (.clk(clk), .reset(reset), .d(sum[1]), .q(q[1]));
+  dff dff2 (.clk(clk), .reset(reset), .d(sum[2]), .q(q[2]));
+  dff dff3 (.clk(clk), .reset(reset), .d(sum[3]), .q(q[3]));
+
+  assign count = q;
+endmodule

--- a/up_down_counter_tb.v
+++ b/up_down_counter_tb.v
@@ -1,0 +1,98 @@
+//============================================================
+// Verilog testbench for 4-bit up/down counters
+// Instantiates behavioral, dataflow, and structural versions
+//============================================================
+`timescale 1ns/1ps
+module tb_up_down_counter;
+  reg        clk;
+  reg        reset;
+  reg        up;
+  wire [3:0] count_behav;
+  wire [3:0] count_data;
+  wire [3:0] count_struct;
+  reg  [3:0] expected;
+  integer    i;
+  integer    errors;
+
+  // Devices Under Test
+  up_down_counter_behavioral dut_behav (
+    .clk   (clk),
+    .reset (reset),
+    .up    (up),
+    .count (count_behav)
+  );
+
+  up_down_counter_dataflow dut_data (
+    .clk   (clk),
+    .reset (reset),
+    .up    (up),
+    .count (count_data)
+  );
+
+  up_down_counter_structural dut_struct (
+    .clk   (clk),
+    .reset (reset),
+    .up    (up),
+    .count (count_struct)
+  );
+
+  // clock generator: 100MHz
+  initial begin
+    clk = 0;
+    forever #5 clk = ~clk;
+  end
+
+  initial begin
+    errors   = 0;
+    expected = 4'd0;
+    reset    = 1'b1; // apply reset for one cycle
+    up       = 1'b1; // start with count up
+    @(posedge clk);  // allow reset to propagate
+    #1 reset = 1'b0; // release reset after clock edge
+
+    // count up for 10 cycles
+    for (i = 0; i < 10; i = i + 1) begin
+      @(posedge clk);
+      #1; // wait for counter update
+      expected = expected + 1;
+      if (count_behav !== expected) begin
+        $display("UP BEHAV ERROR: exp=%0d got=%0d", expected, count_behav);
+        errors = errors + 1;
+      end
+      if (count_data !== expected) begin
+        $display("UP DATA ERROR: exp=%0d got=%0d", expected, count_data);
+        errors = errors + 1;
+      end
+      if (count_struct !== expected) begin
+        $display("UP STRUCT ERROR: exp=%0d got=%0d", expected, count_struct);
+        errors = errors + 1;
+      end
+    end
+
+    // now count down for 10 cycles
+    up = 1'b0;
+    for (i = 0; i < 10; i = i + 1) begin
+      @(posedge clk);
+      #1; // wait for counter update
+      expected = expected - 1;
+      if (count_behav !== expected) begin
+        $display("DOWN BEHAV ERROR: exp=%0d got=%0d", expected, count_behav);
+        errors = errors + 1;
+      end
+      if (count_data !== expected) begin
+        $display("DOWN DATA ERROR: exp=%0d got=%0d", expected, count_data);
+        errors = errors + 1;
+      end
+      if (count_struct !== expected) begin
+        $display("DOWN STRUCT ERROR: exp=%0d got=%0d", expected, count_struct);
+        errors = errors + 1;
+      end
+    end
+
+    if (errors == 0)
+      $display("PASS: all up/down counter implementations verified.");
+    else
+      $display("FAIL: %0d mismatches detected.", errors);
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
## Summary
- add behavioral 4-bit up/down counter derived from Morris Mano
- add dataflow variant using continuous assignments for next state
- add structural counter built from flip-flops and full adders
- unify testbench to exercise and verify all three implementations

## Testing
- `iverilog -o up_down_counter_tb up_down_counter_behavioral.v up_down_counter_dataflow.v up_down_counter_structural.v up_down_counter_tb.v && vvp up_down_counter_tb`


------
https://chatgpt.com/codex/tasks/task_e_68af36cac28483318104a03215299139